### PR TITLE
Check for artifact presence before publising

### DIFF
--- a/src/main/kotlin/io/spine/publishing/Application.kt
+++ b/src/main/kotlin/io/spine/publishing/Application.kt
@@ -42,7 +42,7 @@ object Application {
         val jwtFactory = SignedJwts(privateKeyPath)
         val gitHubApp = GitHubApp(appId, jwtFactory)
         val installationToken = gitHubApp.tokenFactory().newToken()
-        PublishingPipeline(remoteLibs, installationToken).eval()
+        PublishingPipeline(LibrariesToPublish.from(remoteLibs), installationToken).eval()
     }
 }
 

--- a/src/main/kotlin/io/spine/publishing/Artifact.kt
+++ b/src/main/kotlin/io/spine/publishing/Artifact.kt
@@ -59,7 +59,7 @@ data class Artifact(val groupId: GroupId,
                     val artifactName: String) {
 
     init {
-        checkState(!artifactName.isNotBlank(), "Cannot create artifact" +
+        checkState(artifactName.isNotBlank(), "Cannot create artifact" +
                 "with a blank name.")
     }
 }

--- a/src/main/kotlin/io/spine/publishing/Artifact.kt
+++ b/src/main/kotlin/io/spine/publishing/Artifact.kt
@@ -27,12 +27,10 @@ import com.google.api.client.util.Preconditions.checkState
  *
  * For example: a group ID "org.apache.maven.plugins", consists of the following parts:
  *
- * <ol>
- *     <li> "org";
- *     <li> "apache";
- *     <li> "maven";
- *     <li> "plugins".
- * </ol>
+ * 1) "org";
+ * 2) "apache";
+ * 3) "maven";
+ * 4) "plugins".
  */
 typealias GroupIdPart = String
 

--- a/src/main/kotlin/io/spine/publishing/Artifact.kt
+++ b/src/main/kotlin/io/spine/publishing/Artifact.kt
@@ -26,10 +26,13 @@ import com.google.api.client.util.Preconditions.checkState
  * A part of a Maven group ID.
  *
  * For example: a group ID "org.apache.maven.plugins", consists of the following parts:
- * 1) "org";
- * 2) "apache";
- * 3) "maven";
- * 4) "plugins".
+ *
+ * <ol>
+ *     <li> "org";
+ *     <li> "apache";
+ *     <li> "maven";
+ *     <li> "plugins".
+ * </ol>
  */
 typealias GroupIdPart = String
 
@@ -60,6 +63,6 @@ data class Artifact(val groupId: GroupId,
 
     init {
         checkState(artifactName.isNotBlank(), "Cannot create artifact" +
-                "with a blank name.")
+                " with a blank name.")
     }
 }

--- a/src/main/kotlin/io/spine/publishing/Artifact.kt
+++ b/src/main/kotlin/io/spine/publishing/Artifact.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.publishing
+
+import com.google.api.client.util.Preconditions.checkState
+
+/**
+ * A part of a Maven group ID.
+ *
+ * For example: a group ID "org.apache.maven.plugins", consists of the following parts:
+ * 1) "org";
+ * 2) "apache";
+ * 3) "maven";
+ * 4) "plugins".
+ */
+typealias GroupIdPart = String
+
+/**
+ * A Maven group ID.
+ *
+ * @param parts parts of the group ID; refer to [GroupId] docs
+ */
+data class GroupId(val parts: List<GroupIdPart>) {
+
+    constructor(vararg parts: GroupIdPart) : this(parts.toList())
+
+    init {
+        checkState(parts.isNotEmpty(), "Cannot create an empty Group ID.")
+    }
+
+    override fun toString(): String = parts.joinToString(separator = ".")
+}
+
+/**
+ * An artifact published to a Maven repository.
+ *
+ * @param groupId group ID of the artifact
+ * @param artifactName the name of the artifact
+ */
+data class Artifact(val groupId: GroupId,
+                    val artifactName: String) {
+
+    init {
+        checkState(!artifactName.isNotBlank(), "Cannot create artifact" +
+                "with a blank name.")
+    }
+}

--- a/src/main/kotlin/io/spine/publishing/LibrariesToPublish.kt
+++ b/src/main/kotlin/io/spine/publishing/LibrariesToPublish.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.publishing
+
+import com.google.api.client.util.Preconditions.checkArgument
+
+/**
+ * Libraries that participate in the [PublishingPipeline].
+ *
+ * Publishing pipeline starts with an update of a single library: [updatedLibrary]. The [rest] of
+ * the libraries need to have their versions updated to the version of the [updatedLibrary].
+ *
+ * @param updatedLibrary the library that got its version updated
+ * @param rest the libraries that need their version updated to that of [updatedLibrary]
+ */
+class LibrariesToPublish private constructor(val updatedLibrary: Library, val rest: Set<Library>) {
+
+    companion object {
+
+        /**
+         * Constructs [LibrariesToPublish] from the specified set of libraries.
+         *
+         * Finds library with the highest version - this library was updated and initiated the
+         * publishing. Sets the [updatedLibrary] to the library with the highest version, and puts
+         * the rest of the libraries into [rest].
+         *
+         * Throws an `IllegalArgumentsException` if the [set] is empty.
+         *
+         * @param set a set of libraries to publish; must be non-empty
+         */
+        fun from(set: Set<Library>): LibrariesToPublish {
+            checkArgument(set.isNotEmpty(), "Cannot update an empty set of libraries.")
+
+            val updatedLibrary = set.maxBy { it.version() }!!
+            val rest = set.filter { it != updatedLibrary }.toSet()
+
+            return LibrariesToPublish(updatedLibrary, rest)
+        }
+    }
+
+    /**
+     * Returns the set of all the libraries that are being updated.
+     */
+    fun toSet(): Set<Library> {
+        val result = rest.toMutableSet()
+        result.add(updatedLibrary)
+        return result
+    }
+}

--- a/src/main/kotlin/io/spine/publishing/LibrariesToPublish.kt
+++ b/src/main/kotlin/io/spine/publishing/LibrariesToPublish.kt
@@ -48,7 +48,7 @@ class LibrariesToPublish private constructor(val updatedLibraries: Set<Library>,
          *
          * Throws an `IllegalArgumentsException` if the [set] is empty.
          *
-         * @param set a set of libraries to publish; must be on-empty
+         * @param set a set of libraries to publish; must be non-empty
          * @param transport transport to use when querying the artifact repository
          */
         fun from(set: Set<Library>, transport: HttpTransport = NetHttpTransport()): LibrariesToPublish {

--- a/src/main/kotlin/io/spine/publishing/Library.kt
+++ b/src/main/kotlin/io/spine/publishing/Library.kt
@@ -42,7 +42,8 @@ typealias LibraryName = String
  */
 data class Library(val name: LibraryName,
                    val dependencies: List<Library>,
-                   val repository: GitRepository) {
+                   val repository: GitRepository,
+                   val artifact: Artifact) {
 
     /**
      * Updates the version of this library to the specified one.

--- a/src/main/kotlin/io/spine/publishing/PublishingPipeline.kt
+++ b/src/main/kotlin/io/spine/publishing/PublishingPipeline.kt
@@ -1,11 +1,7 @@
 package io.spine.publishing
 
 import io.spine.publishing.git.GitHubToken
-import io.spine.publishing.operation.SetToCurrentRemote
-import io.spine.publishing.operation.UpdateVersions
-import io.spine.publishing.operation.EnsureBuilds
-import io.spine.publishing.operation.Publish
-import io.spine.publishing.operation.UpdateRemote
+import io.spine.publishing.operation.*
 
 /**
  * A series of operations to perform over a set of libraries in order to update them and
@@ -22,7 +18,7 @@ import io.spine.publishing.operation.UpdateRemote
  * @param libraries libraries to update and publish
  * @param operations operations to perform over the libraries in order to update and publish them
  */
-class PublishingPipeline(val libraries: Set<Library>,
+class PublishingPipeline(val libraries: LibrariesToPublish,
                          private val operations: List<PipelineOperation>) {
 
     /**
@@ -33,7 +29,7 @@ class PublishingPipeline(val libraries: Set<Library>,
      * @param libraries libraries to update and publish
      * @param token a token that authorizes GitHub operations
      */
-    constructor(libraries: Set<Library>, token: GitHubToken) :
+    constructor(libraries: LibrariesToPublish, token: GitHubToken) :
             this(libraries, listOf(
                     SetToCurrentRemote(),
                     UpdateVersions(),
@@ -80,16 +76,20 @@ abstract class PipelineOperation {
      * Perform this operation over the specified set of libraries.
      *
      * Returns [Ok] if the operation has finished successfully, and [Error] otherwise.
+     *
+     * @param libraries the libraries participating in the publishing pipeline
      */
-    abstract fun perform(libraries: Set<Library>): OperationResult
+    abstract fun perform(libraries: LibrariesToPublish): OperationResult
 
     /**
      * Tries to perform this operation over a set of libraries.
      *
      * If it finishes normally, returns the result of [perform]. If an exception is thrown,
      * returns an [Error].
+     *
+     * @param libraries the libraries participating in the publishing pipeline
      */
-    fun doPerform(libraries: Set<Library>): OperationResult {
+    fun doPerform(libraries: LibrariesToPublish): OperationResult {
         return try {
             perform(libraries)
         } catch (e: Exception) {

--- a/src/main/kotlin/io/spine/publishing/SpineCloudRepoArtifact.kt
+++ b/src/main/kotlin/io/spine/publishing/SpineCloudRepoArtifact.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.publishing
+
+import com.google.api.client.http.GenericUrl
+import com.google.api.client.http.HttpStatusCodes.STATUS_CODE_MULTIPLE_CHOICES
+import com.google.api.client.http.HttpStatusCodes.STATUS_CODE_OK
+import com.google.api.client.http.HttpTransport
+import com.google.api.client.http.javanet.NetHttpTransport
+import io.spine.publishing.gradle.Version
+
+/**
+ * An artifact in [Spine CloudRepo](https://spine.mycloudrepo.io/public/repositories/)
+ * artifact repository.
+ */
+class SpineCloudRepoArtifact(private val artifact: Artifact,
+                             transport: HttpTransport = NetHttpTransport()) {
+
+    private val requestFactory = transport.createRequestFactory()
+
+    /**
+     * Returns whether an artifact of the specified version is present in the artifact repository.
+     */
+    fun isPublished(version: Version): Boolean {
+        val url = url(version)
+        val response = requestFactory.buildGetRequest(GenericUrl(url))
+                .setThrowExceptionOnExecuteError(false)
+                .execute()
+        return when (response.statusCode) {
+            in (STATUS_CODE_OK until STATUS_CODE_MULTIPLE_CHOICES) -> true
+            404 -> false
+            else -> throw IllegalStateException("Could not determine whether artifact " +
+                    "${artifact.artifactName} is published: mycloudrepo returned an unexpected" +
+                    "response. " +
+                    "Code: `${response.statusCode}`, " +
+                    "response: ${response.content.bufferedReader().lines()}")
+        }
+    }
+
+    /**
+     * Construct a URL to this artifact of the specified version.
+     *
+     * Visible for testing.
+     */
+    internal fun url(version: Version): String {
+        val resultBuilder = StringBuilder()
+        resultBuilder.append("https://")
+
+        val urlParts = mutableListOf("spine.mycloudrepo.io",
+                "public",
+                "repositories",
+                "releases"
+        )
+        urlParts.addAll(artifact.groupId.parts)
+        urlParts.add(artifact.artifactName)
+        urlParts.add(version.toString())
+        val url = urlParts.joinToString(separator = "/", postfix = "/")
+        resultBuilder.append(url)
+        return resultBuilder.toString()
+    }
+}

--- a/src/main/kotlin/io/spine/publishing/SpineCloudRepoArtifact.kt
+++ b/src/main/kotlin/io/spine/publishing/SpineCloudRepoArtifact.kt
@@ -30,6 +30,9 @@ import io.spine.publishing.gradle.Version
 /**
  * An artifact in [Spine CloudRepo](https://spine.mycloudrepo.io/public/repositories/)
  * artifact repository.
+ *
+ * @param artifact artifact in mycloudrepo
+ * @param transport the transport to use when querying mycloudrepo; overridable for tests
  */
 class SpineCloudRepoArtifact(private val artifact: Artifact,
                              transport: HttpTransport = NetHttpTransport()) {
@@ -39,7 +42,11 @@ class SpineCloudRepoArtifact(private val artifact: Artifact,
     /**
      * Returns whether an artifact of the specified version is present in the artifact repository.
      *
+     * Queries the remote artifact repository. If it responds with a successful status code, returns
+     * `true`. If the remote repository returns a "Not Found" status, returns `false`. Otherwise,
+     * throws an `IllegalStateException`.
      *
+     * @param version the version of the artifact to check
      */
     fun isPublished(version: Version): Boolean {
         val url = url(version)
@@ -62,6 +69,8 @@ class SpineCloudRepoArtifact(private val artifact: Artifact,
      * Construct a URL to this artifact of the specified version.
      *
      * Visible for testing.
+     *
+     * @param version the version of the artifact to check
      */
     internal fun url(version: Version): String {
         val resultBuilder = StringBuilder()

--- a/src/main/kotlin/io/spine/publishing/SpineLibrary.kt
+++ b/src/main/kotlin/io/spine/publishing/SpineLibrary.kt
@@ -42,12 +42,19 @@ enum class SpineLibrary(val library: Library) {
  */
 private const val ORGANIZATION = "SpineEventEngine"
 
+private val GROUP_ID = GroupId("io", "spine")
+
 private val baseRepo = GitRepository(Paths.get("base"), remoteRepo("base"))
 private val timeRepo = GitRepository(Paths.get("time"), remoteRepo("time"))
 private val coreJavaRepo = GitRepository(Paths.get("core-java"), remoteRepo("core-java"))
 
-private val base = Library("base", listOf(), baseRepo)
-private val time = Library("time", listOf(base), timeRepo)
-private val coreJava = Library("coreJava", listOf(base, time), coreJavaRepo)
+// TODO: 2020-08-19:serhii.lekariev: https://github.com/SpineEventEngine/publishing/issues/10
+private val baseArtifact = Artifact(GROUP_ID, "spine-base")
+private val timeArtifact = Artifact(GROUP_ID, "spine-time")
+private val coreArtifact = Artifact(GROUP_ID, "spine-core")
+
+private val base = Library("base", listOf(), baseRepo, baseArtifact)
+private val time = Library("time", listOf(base), timeRepo, timeArtifact)
+private val coreJava = Library("coreJava", listOf(base, time), coreJavaRepo, coreArtifact)
 
 private fun remoteRepo(name: RepositoryName) = GitHubRepoUrl(ORGANIZATION, name)

--- a/src/main/kotlin/io/spine/publishing/gradle/GradleProject.kt
+++ b/src/main/kotlin/io/spine/publishing/gradle/GradleProject.kt
@@ -40,7 +40,8 @@ data class GradleProject(private val rootDir: Path) {
      *
      * Returns `false` if the task has failed.
      */
-    fun build(): Boolean = runCommand("build")
+    fun buildNoVersionIncrementCheck(): Boolean =
+            runCommand("build", "-x", "checkVersionIncrement")
 
     /**
      * Runs the `build` task on this project.

--- a/src/main/kotlin/io/spine/publishing/gradle/GradleProject.kt
+++ b/src/main/kotlin/io/spine/publishing/gradle/GradleProject.kt
@@ -36,11 +36,12 @@ data class GradleProject(private val rootDir: Path) {
     }
 
     /**
-     * Runs the `build` task on this project.
+     * Runs the `build -x checkVersionIncrement` task on this project.
      *
      * Returns `false` if the task has failed.
      */
-    fun build(): Boolean = runCommand("build")
+    fun buildNoVersionIncrementCheck(): Boolean =
+            runCommand("build", "-x", "checkVersionIncrement")
 
     /**
      * Runs the `build` task on this project.

--- a/src/main/kotlin/io/spine/publishing/gradle/GradleProject.kt
+++ b/src/main/kotlin/io/spine/publishing/gradle/GradleProject.kt
@@ -36,6 +36,13 @@ data class GradleProject(private val rootDir: Path) {
     }
 
     /**
+     * Runs the `build` task on this project.
+     *
+     * Returns `false` if the task has failed.
+     */
+    fun build(): Boolean = runCommand("build")
+
+    /**
      * Runs the `build` task on this project, but skips the `checkVersionIncrement` task.
      *
      * Returns `false` if the task has failed.

--- a/src/main/kotlin/io/spine/publishing/gradle/GradleProject.kt
+++ b/src/main/kotlin/io/spine/publishing/gradle/GradleProject.kt
@@ -40,8 +40,7 @@ data class GradleProject(private val rootDir: Path) {
      *
      * Returns `false` if the task has failed.
      */
-    fun buildNoVersionIncrementCheck(): Boolean =
-            runCommand("build", "-x", "checkVersionIncrement")
+    fun build(): Boolean = runCommand("build")
 
     /**
      * Runs the `build` task on this project.

--- a/src/main/kotlin/io/spine/publishing/gradle/GradleProject.kt
+++ b/src/main/kotlin/io/spine/publishing/gradle/GradleProject.kt
@@ -44,7 +44,7 @@ data class GradleProject(private val rootDir: Path) {
             runCommand("build", "-x", "checkVersionIncrement")
 
     /**
-     * Runs the `build` task on this project.
+     * Runs the `publish` task on this project.
      *
      * Returns `false` if the task has failed.
      */

--- a/src/main/kotlin/io/spine/publishing/gradle/GradleProject.kt
+++ b/src/main/kotlin/io/spine/publishing/gradle/GradleProject.kt
@@ -36,7 +36,7 @@ data class GradleProject(private val rootDir: Path) {
     }
 
     /**
-     * Runs the `build -x checkVersionIncrement` task on this project.
+     * Runs the `build` task on this project, but skips the `checkVersionIncrement` task.
      *
      * Returns `false` if the task has failed.
      */

--- a/src/main/kotlin/io/spine/publishing/operation/EnsureBuilds.kt
+++ b/src/main/kotlin/io/spine/publishing/operation/EnsureBuilds.kt
@@ -1,10 +1,6 @@
 package io.spine.publishing.operation
 
-import io.spine.publishing.Library
-import io.spine.publishing.Ok
-import io.spine.publishing.Error
-import io.spine.publishing.OperationResult
-import io.spine.publishing.PipelineOperation
+import io.spine.publishing.*
 import io.spine.publishing.gradle.GradleProject
 import io.spine.publishing.gradle.Ordering
 
@@ -39,6 +35,10 @@ class EnsureBuilds : PipelineOperation() {
      * Returns [Ok] if all of the libraries are built successfully. Returns [Error] if a library
      * could not be built or published to the local Maven repo.
      *
+     * All of the libraries are built without checking the version increment. The builds are
+     * performed to check whether the library is valid, thus, the version increment check is
+     * redundant.
+     *
      * @param libraries a collection of interdependent libraries to check
      *
      * @see Ordering for a dependency-safe way to order libraries
@@ -47,7 +47,7 @@ class EnsureBuilds : PipelineOperation() {
         val ordered = Ordering(libraries).byDependencies
         for (library in ordered) {
             val gradleProject = GradleProject(library.repository.localRootPath)
-            val builds = gradleProject.build()
+            val builds = gradleProject.buildNoVersionIncrementCheck()
             if (!builds) {
                 return Error(cannotBuild(library, libraries))
             }

--- a/src/main/kotlin/io/spine/publishing/operation/EnsureBuilds.kt
+++ b/src/main/kotlin/io/spine/publishing/operation/EnsureBuilds.kt
@@ -35,6 +35,10 @@ class EnsureBuilds : PipelineOperation() {
      * Returns [Ok] if all of the libraries are built successfully. Returns [Error] if a library
      * could not be built or published to the local Maven repo.
      *
+     * All of the libraries are built without checking the version increment. The builds are
+     * performed to check whether the library is valid, thus, the version increment check is
+     * redundant.
+     *
      * @param libraries a collection of interdependent libraries to check
      *
      * @see Ordering for a dependency-safe way to order libraries
@@ -43,7 +47,7 @@ class EnsureBuilds : PipelineOperation() {
         val ordered = Ordering(libraries).byDependencies
         for (library in ordered) {
             val gradleProject = GradleProject(library.repository.localRootPath)
-            val builds = gradleProject.build()
+            val builds = gradleProject.buildNoVersionIncrementCheck()
             if (!builds) {
                 return Error(cannotBuild(library, libraries))
             }

--- a/src/main/kotlin/io/spine/publishing/operation/EnsureBuilds.kt
+++ b/src/main/kotlin/io/spine/publishing/operation/EnsureBuilds.kt
@@ -60,7 +60,7 @@ class EnsureBuilds : PipelineOperation() {
 
     private fun build(library: Library, libraries: LibrariesToPublish): Boolean {
         val project = GradleProject(library.repository.localRootPath)
-        return if (library == libraries.updatedLibrary) {
+        return if (libraries.updatedLibraries.contains(library)) {
             project.buildNoVersionIncrementCheck()
         } else {
             project.build()

--- a/src/main/kotlin/io/spine/publishing/operation/EnsureBuilds.kt
+++ b/src/main/kotlin/io/spine/publishing/operation/EnsureBuilds.kt
@@ -35,10 +35,6 @@ class EnsureBuilds : PipelineOperation() {
      * Returns [Ok] if all of the libraries are built successfully. Returns [Error] if a library
      * could not be built or published to the local Maven repo.
      *
-     * All of the libraries are built without checking the version increment. The builds are
-     * performed to check whether the library is valid, thus, the version increment check is
-     * redundant.
-     *
      * @param libraries a collection of interdependent libraries to check
      *
      * @see Ordering for a dependency-safe way to order libraries
@@ -47,7 +43,7 @@ class EnsureBuilds : PipelineOperation() {
         val ordered = Ordering(libraries).byDependencies
         for (library in ordered) {
             val gradleProject = GradleProject(library.repository.localRootPath)
-            val builds = gradleProject.buildNoVersionIncrementCheck()
+            val builds = gradleProject.build()
             if (!builds) {
                 return Error(cannotBuild(library, libraries))
             }

--- a/src/main/kotlin/io/spine/publishing/operation/Publish.kt
+++ b/src/main/kotlin/io/spine/publishing/operation/Publish.kt
@@ -12,7 +12,7 @@ class Publish : PipelineOperation() {
 
     override fun perform(libraries: Set<Library>): OperationResult {
         libraries
-                .filter { SpineCloudRepoArtifact(it.artifact).isPublished(it.version()) }
+                .filter { !SpineCloudRepoArtifact(it.artifact).isPublished(it.version()) }
                 .map { GradleProject(it.repository.localRootPath) }
                 .forEach { it.publish() }
         return Ok

--- a/src/main/kotlin/io/spine/publishing/operation/Publish.kt
+++ b/src/main/kotlin/io/spine/publishing/operation/Publish.kt
@@ -12,8 +12,7 @@ class Publish : PipelineOperation() {
 
     override fun perform(libraries: LibrariesToPublish): OperationResult {
         libraries
-                .toSet()
-                .filter { !SpineCloudRepoArtifact(it.artifact).isPublished(it.version()) }
+                .rest
                 .map { GradleProject(it.repository.localRootPath) }
                 .forEach { it.publish() }
         return Ok

--- a/src/main/kotlin/io/spine/publishing/operation/Publish.kt
+++ b/src/main/kotlin/io/spine/publishing/operation/Publish.kt
@@ -1,9 +1,6 @@
 package io.spine.publishing.operation
 
-import io.spine.publishing.Library
-import io.spine.publishing.Ok
-import io.spine.publishing.OperationResult
-import io.spine.publishing.PipelineOperation
+import io.spine.publishing.*
 import io.spine.publishing.gradle.GradleProject
 
 /**
@@ -14,7 +11,9 @@ import io.spine.publishing.gradle.GradleProject
 class Publish : PipelineOperation() {
 
     override fun perform(libraries: Set<Library>): OperationResult {
-        libraries.map { GradleProject(it.repository.localRootPath) }
+        libraries
+                .filter { SpineCloudRepoArtifact(it.artifact).isPublished(it.version()) }
+                .map { GradleProject(it.repository.localRootPath) }
                 .forEach { it.publish() }
         return Ok
     }

--- a/src/main/kotlin/io/spine/publishing/operation/Publish.kt
+++ b/src/main/kotlin/io/spine/publishing/operation/Publish.kt
@@ -10,8 +10,9 @@ import io.spine.publishing.gradle.GradleProject
  */
 class Publish : PipelineOperation() {
 
-    override fun perform(libraries: Set<Library>): OperationResult {
+    override fun perform(libraries: LibrariesToPublish): OperationResult {
         libraries
+                .toSet()
                 .filter { !SpineCloudRepoArtifact(it.artifact).isPublished(it.version()) }
                 .map { GradleProject(it.repository.localRootPath) }
                 .forEach { it.publish() }

--- a/src/main/kotlin/io/spine/publishing/operation/SetToCurrentRemote.kt
+++ b/src/main/kotlin/io/spine/publishing/operation/SetToCurrentRemote.kt
@@ -1,9 +1,6 @@
 package io.spine.publishing.operation
 
-import io.spine.publishing.Library
-import io.spine.publishing.Ok
-import io.spine.publishing.OperationResult
-import io.spine.publishing.PipelineOperation
+import io.spine.publishing.*
 import io.spine.publishing.git.Fetch
 import io.spine.publishing.git.GitCommand
 import io.spine.publishing.git.Reset
@@ -14,8 +11,9 @@ import io.spine.publishing.git.ToOriginMaster
  */
 class SetToCurrentRemote : PipelineOperation() {
 
-    override fun perform(libraries: Set<Library>): OperationResult {
-        libraries.flatMap { fetchFresh(it) }
+    override fun perform(libraries: LibrariesToPublish): OperationResult {
+        libraries.toSet()
+                .flatMap { fetchFresh(it) }
                 .forEach { it.execute() }
         return Ok
     }

--- a/src/main/kotlin/io/spine/publishing/operation/UpdateRemote.kt
+++ b/src/main/kotlin/io/spine/publishing/operation/UpdateRemote.kt
@@ -1,18 +1,7 @@
 package io.spine.publishing.operation
 
-import io.spine.publishing.Library
-import io.spine.publishing.Ok
-import io.spine.publishing.OperationResult
-import io.spine.publishing.PipelineOperation
-import io.spine.publishing.git.GitHubToken
-import io.spine.publishing.git.Master
-import io.spine.publishing.git.StageFiles
-import io.spine.publishing.git.VersionFile
-import io.spine.publishing.git.GitCommand
-import io.spine.publishing.git.Commit
-import io.spine.publishing.git.VersionBumpMessage
-import io.spine.publishing.git.PushToRemote
-import io.spine.publishing.git.Checkout
+import io.spine.publishing.*
+import io.spine.publishing.git.*
 
 /**
  * Propagates local [Library] changes to the
@@ -42,7 +31,7 @@ class UpdateRemote(private val token: GitHubToken) : PipelineOperation() {
          * @param token a token to authorize the version update
          */
         internal fun updateVersion(library: Library,
-                          token: GitHubToken): List<GitCommand> = listOf(
+                                   token: GitHubToken): List<GitCommand> = listOf(
                 Checkout(Master(library)),
                 StageFiles(VersionFile(library)),
                 Commit(VersionBumpMessage(library)),
@@ -50,8 +39,8 @@ class UpdateRemote(private val token: GitHubToken) : PipelineOperation() {
         )
     }
 
-    override fun perform(libraries: Set<Library>): OperationResult {
-        for (library in libraries) {
+    override fun perform(libraries: LibrariesToPublish): OperationResult {
+        for (library in libraries.toSet()) {
             val commands = updateVersion(library, token)
             commands.forEach { it.execute() }
         }

--- a/src/main/kotlin/io/spine/publishing/operation/UpdateVersions.kt
+++ b/src/main/kotlin/io/spine/publishing/operation/UpdateVersions.kt
@@ -1,9 +1,6 @@
 package io.spine.publishing.operation
 
-import io.spine.publishing.Library
-import io.spine.publishing.Ok
-import io.spine.publishing.OperationResult
-import io.spine.publishing.PipelineOperation
+import io.spine.publishing.*
 import io.spine.publishing.gradle.Version
 
 /**
@@ -13,11 +10,13 @@ import io.spine.publishing.gradle.Version
  */
 class UpdateVersions : PipelineOperation() {
 
-    override fun perform(libraries: Set<Library>): OperationResult {
+    override fun perform(libraries: LibrariesToPublish): OperationResult {
         // The collection is non-empty as per the pipeline contract - non-null assertion is safe.
-        val maxVersion = libraries.maxBy { it.version() }!!
+        val maxVersion = libraries
+                .toSet()
+                .maxBy { it.version() }!!
                 .version()
-        libraries
+        libraries.toSet()
                 .filter { needsUpdate(it, maxVersion) }
                 .forEach { library -> library.update(maxVersion) }
 

--- a/src/test/kotlin/io/spine/publishing/LibrariesToPublishTest.kt
+++ b/src/test/kotlin/io/spine/publishing/LibrariesToPublishTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.publishing
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("`LibrariesToPublish` should")
+class LibrariesToPublishTest {
+
+    @Test
+    @DisplayName("throw an exception when attempting to create from an empty set")
+    fun emptySetException() {
+        assertThrows<IllegalArgumentException> {
+            LibrariesToPublish.from(setOf())
+        }
+    }
+}

--- a/src/test/kotlin/io/spine/publishing/LibraryTest.kt
+++ b/src/test/kotlin/io/spine/publishing/LibraryTest.kt
@@ -41,15 +41,20 @@ class LibraryTest {
         private const val DEPENDANT = "dependant"
         private val REMOTE_DEPENDENCY = GitHubRepoUrl("mockOrg", DEPENDENCY)
         private val REMOTE_DEPENDANT = GitHubRepoUrl("mockOrg", DEPENDANT)
+        private val mockGroupId = GroupId("org", "mock")
 
         private fun dependencyLibrary(directory: Path): Library =
-                Library(DEPENDENCY, arrayListOf(), GitRepository(directory, REMOTE_DEPENDENCY))
+                Library(DEPENDENCY,
+                        arrayListOf(),
+                        GitRepository(directory, REMOTE_DEPENDENCY),
+                        Artifact(mockGroupId, "dependency"))
 
         private fun dependantLibrary(directory: Path,
                                      dependency: Library): Library {
             return Library(DEPENDANT,
                     arrayListOf(dependency),
-                    GitRepository(directory, REMOTE_DEPENDANT))
+                    GitRepository(directory, REMOTE_DEPENDANT),
+                    Artifact(mockGroupId, "dependant"))
         }
     }
 
@@ -108,7 +113,8 @@ class LibraryTest {
         {
             Library("no_git_repo_library",
                     listOf(),
-                    GitRepository(tempDir, REMOTE_DEPENDENCY)).repository.localGitRepository()
+                    GitRepository(tempDir, REMOTE_DEPENDENCY),
+                    Artifact(mockGroupId, "library")).repository.localGitRepository()
         }
     }
 }

--- a/src/test/kotlin/io/spine/publishing/PublishingPipelineTest.kt
+++ b/src/test/kotlin/io/spine/publishing/PublishingPipelineTest.kt
@@ -1,6 +1,7 @@
 package io.spine.publishing
 
 import assertk.assertThat
+import assertk.assertions.contains
 import assertk.assertions.containsOnly
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNull
@@ -40,10 +41,10 @@ class PublishingPipelineTest {
 
         val result = pipeline(firstCollecting, secondCollecting).eval()
         assertThat(result).isInstanceOf(Ok::class)
-        assertThat(firstCollecting.seenLibraries()).containsOnly(sampleLibrary)
-        assertThat(secondCollecting.seenLibraries()).containsOnly(sampleLibrary)
+        assertThat(firstCollecting.seenLibraries()).containsOnly(sampleLibrary())
+        assertThat(secondCollecting.seenLibraries()).containsOnly(sampleLibrary())
     }
 
     private fun pipeline(vararg operations: PipelineOperation) =
-            PublishingPipeline(LibrariesToPublish.from(setOf(sampleLibrary)), operations.toList())
+            PublishingPipeline(LibrariesToPublish.from(setOf(sampleLibrary())), operations.toList())
 }

--- a/src/test/kotlin/io/spine/publishing/PublishingPipelineTest.kt
+++ b/src/test/kotlin/io/spine/publishing/PublishingPipelineTest.kt
@@ -45,5 +45,5 @@ class PublishingPipelineTest {
     }
 
     private fun pipeline(vararg operations: PipelineOperation) =
-            PublishingPipeline(setOf(sampleLibrary), operations.toList())
+            PublishingPipeline(LibrariesToPublish.from(setOf(sampleLibrary)), operations.toList())
 }

--- a/src/test/kotlin/io/spine/publishing/SpineCloudRepoArtifactTest.kt
+++ b/src/test/kotlin/io/spine/publishing/SpineCloudRepoArtifactTest.kt
@@ -38,6 +38,7 @@ import org.junit.jupiter.params.provider.MethodSource
 @DisplayName("`SpineCloudRepoArtifact` should")
 class SpineCloudRepoArtifactTest {
 
+    @Suppress("unused" /* The static methods are used via reflection. */)
     companion object {
 
         private val artifact = Artifact(GroupId("com", "acme"), "tnt")

--- a/src/test/kotlin/io/spine/publishing/SpineCloudRepoArtifactTest.kt
+++ b/src/test/kotlin/io/spine/publishing/SpineCloudRepoArtifactTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.publishing
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import com.google.api.client.http.HttpStatusCodes.STATUS_CODE_NOT_FOUND
+import com.google.api.client.http.HttpTransport
+import io.spine.publishing.github.given.GitHubRequestsTestEnv.transportThatRespondsWith
+import io.spine.publishing.gradle.Version
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+@DisplayName("`SpineCloudRepoArtifact` should")
+class SpineCloudRepoArtifactTest {
+
+    companion object {
+
+        private val artifact = Artifact(GroupId("com", "acme"), "tnt")
+        private val mockVersion = Version(1, 1, 1)
+
+        fun mockArtifact(transport: HttpTransport) = SpineCloudRepoArtifact(artifact, transport)
+
+        @JvmStatic
+        fun badCodes() = (500..599).map { arguments(it) }
+
+        @JvmStatic
+        fun goodCodes() = (200..299).map { arguments(it) }
+    }
+
+    @Test
+    @DisplayName("build a correct link to the cloud repo")
+    fun correctUrl() {
+        val expected = "https://spine.mycloudrepo.io/public/repositories/releases/io/spine/spine-core/1.5.21/"
+
+        val artifact = Artifact(GroupId("io", "spine"), "spine-core")
+        val actual = SpineCloudRepoArtifact(artifact).url(Version(1, 5, 21))
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    @DisplayName("tell that the artifact is not published upon seeing a 404")
+    fun notFound() {
+        val transport = transportThatRespondsWith { it.setStatusCode(STATUS_CODE_NOT_FOUND) }
+
+        val isPublished = mockArtifact(transport).isPublished(mockVersion)
+        assertThat(isPublished).isFalse()
+    }
+
+    @ParameterizedTest
+    @DisplayName("throw an exception upon seeing a server error status code")
+    @MethodSource("badCodes")
+    fun statusCode500Plus(code: Int) {
+        val transport = transportThatRespondsWith { it.setStatusCode(code) }
+        assertThrows<IllegalStateException> {
+            mockArtifact(transport).isPublished(mockVersion)
+        }
+    }
+
+    @ParameterizedTest
+    @DisplayName("tell that the artifact is published upon seeing a successful code")
+    @MethodSource("goodCodes")
+    fun successfulStatusCode(code: Int) {
+        val transport = transportThatRespondsWith { it.setStatusCode(code) }
+        val isPublished = mockArtifact(transport).isPublished(mockVersion)
+        assertThat(isPublished).isTrue()
+    }
+}

--- a/src/test/kotlin/io/spine/publishing/git/VersionUpdateTest.kt
+++ b/src/test/kotlin/io/spine/publishing/git/VersionUpdateTest.kt
@@ -22,6 +22,8 @@ package io.spine.publishing.git
 
 import assertk.assertThat
 import assertk.assertions.*
+import io.spine.publishing.Artifact
+import io.spine.publishing.GroupId
 import io.spine.publishing.Library
 import io.spine.publishing.github.TokenFactory
 import io.spine.publishing.gradle.GradleVersionFile
@@ -51,7 +53,8 @@ class VersionUpdateTest {
 
         val remote = GitHubRepoUrl(orgName, repo)
         val gitRepo = GitRepository(baseDirectory, remote)
-        val library = Library("base", listOf(), gitRepo)
+        val artifact = Artifact(GroupId("io", "spine"), "spine-base")
+        val library = Library("base", listOf(), gitRepo, artifact)
         val commands = updateVersion(library, mockTokenFactory.newToken())
 
         assertThat(commands).hasSize(4)

--- a/src/test/kotlin/io/spine/publishing/github/JwtRefreshingBackOffTest.kt
+++ b/src/test/kotlin/io/spine/publishing/github/JwtRefreshingBackOffTest.kt
@@ -27,6 +27,7 @@ import com.google.api.client.http.HttpResponseException
 import com.google.api.client.http.HttpStatusCodes.*
 import com.google.api.client.testing.http.MockLowLevelHttpResponse
 import io.spine.publishing.github.given.GitHubRequestsTestEnv.mockJwtValue
+import io.spine.publishing.github.given.GitHubRequestsTestEnv.mockResponse
 import io.spine.publishing.github.given.GitHubRequestsTestEnv.transportWithPresetResponses
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -108,7 +109,4 @@ class JwtRefreshingBackOffTest {
         }
         assertThat(timesRefreshed == 3)
     }
-
-    private fun mockResponse(code: Int) = MockLowLevelHttpResponse()
-            .setStatusCode(code)
 }

--- a/src/test/kotlin/io/spine/publishing/github/given/GitHubRequestsTestEnv.kt
+++ b/src/test/kotlin/io/spine/publishing/github/given/GitHubRequestsTestEnv.kt
@@ -66,6 +66,8 @@ object GitHubRequestsTestEnv {
                 }
             }
 
+    fun mockResponse(code: Int) = MockLowLevelHttpResponse().setStatusCode(code)
+
     const val mockJwtValue = "abcdefgciOiWAUrIsNiJ9.eyJpY3023123O1czMjcxLsVdIaV2vQA2ZD"
 
     fun mockJwt(): GitHubJwt = GitHubJwt(mockJwtValue) { mockJwt() }

--- a/src/test/kotlin/io/spine/publishing/given/PipelineTestEnv.kt
+++ b/src/test/kotlin/io/spine/publishing/given/PipelineTestEnv.kt
@@ -1,9 +1,10 @@
 package io.spine.publishing.given
 
+import com.google.common.io.Files
 import io.spine.publishing.*
 import io.spine.publishing.git.GitHubRepoUrl
 import io.spine.publishing.git.GitRepository
-import java.nio.file.Paths
+import java.nio.file.Path
 
 /**
  * Utilities for testing the [io.spine.publishing.PublishingPipeline]
@@ -12,12 +13,26 @@ object PipelineTestEnv {
 
     val sampleRemote = GitHubRepoUrl("sample_org", "sample_library")
 
-    // The paths is not required for tests, so a mock path is OK.
-    val sampleLibrary =
-            Library("sample_library",
-                    listOf(),
-                    GitRepository(Paths.get(""), sampleRemote),
-                    Artifact(GroupId("hk", "sample"), "library"))
+    private lateinit var versionFile: Path
+
+    private fun copyResourceFile() {
+        val tempDir = Files.createTempDir()
+        versionFile = tempDir.toPath().resolve("version.gradle.kts")
+        versionFile.toFile().createNewFile()
+        @Suppress("RECEIVER_NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
+        val text = PipelineTestEnv::javaClass.get().classLoader.getResource("version.gradle.kts").readText()
+        versionFile.toFile().writeText(text)
+    }
+
+    fun sampleLibrary(): Library {
+        if (!this::versionFile.isInitialized) {
+            copyResourceFile()
+        }
+        return Library("base",
+                listOf(),
+                GitRepository(versionFile.parent, sampleRemote),
+                Artifact(GroupId("hk", "sample"), "library"))
+    }
 
     /**
      * An operation that always throws an exception.

--- a/src/test/kotlin/io/spine/publishing/given/PipelineTestEnv.kt
+++ b/src/test/kotlin/io/spine/publishing/given/PipelineTestEnv.kt
@@ -16,7 +16,8 @@ object PipelineTestEnv {
     val sampleLibrary =
             Library("sample_library",
                     listOf(),
-                    GitRepository(Paths.get(""), sampleRemote))
+                    GitRepository(Paths.get(""), sampleRemote),
+                    Artifact(GroupId("hk", "sample"), "library"))
 
     /**
      * An operation that always throws an exception.

--- a/src/test/kotlin/io/spine/publishing/given/PipelineTestEnv.kt
+++ b/src/test/kotlin/io/spine/publishing/given/PipelineTestEnv.kt
@@ -23,7 +23,7 @@ object PipelineTestEnv {
      * An operation that always throws an exception.
      */
     object ThrowingOperation : PipelineOperation() {
-        override fun perform(libraries: Set<Library>): OperationResult =
+        override fun perform(libraries: LibrariesToPublish): OperationResult =
                 throw IllegalStateException()
 
     }
@@ -32,7 +32,7 @@ object PipelineTestEnv {
      * An operation that always returns an [io.spine.publishing.Error]
      */
     object ErroneousOperation : PipelineOperation() {
-        override fun perform(libraries: Set<Library>): OperationResult =
+        override fun perform(libraries: LibrariesToPublish): OperationResult =
                 Error("An erroneous operation always errors.")
     }
 
@@ -40,8 +40,8 @@ object PipelineTestEnv {
 
         private val seenLibraries: MutableList<Library> = mutableListOf()
 
-        override fun perform(libraries: Set<Library>): OperationResult {
-            seenLibraries.addAll(libraries)
+        override fun perform(libraries: LibrariesToPublish): OperationResult {
+            seenLibraries.addAll(libraries.toSet())
             return Ok
         }
 

--- a/src/test/kotlin/io/spine/publishing/gradle/OrderingTest.kt
+++ b/src/test/kotlin/io/spine/publishing/gradle/OrderingTest.kt
@@ -24,6 +24,8 @@ import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.containsOnly
 import assertk.assertions.isEqualTo
+import io.spine.publishing.Artifact
+import io.spine.publishing.GroupId
 import io.spine.publishing.Library
 import io.spine.publishing.git.GitHubRepoUrl
 import io.spine.publishing.git.GitRepository
@@ -88,13 +90,16 @@ class OrderingTest {
 
         val base = Library("base",
                 listOf(),
-                GitRepository(movedBase, mockRemote("base")))
+                GitRepository(movedBase, mockRemote("base")),
+                Artifact(GroupId("io", "spine"), "spine-base"))
         val time = Library("time",
                 listOf(base),
-                GitRepository(movedTime, mockRemote("time")))
+                GitRepository(movedTime, mockRemote("time")),
+                Artifact(GroupId("io", "spine"), "spine-time"))
         val coreJava = Library("coreJava",
                 listOf(time, base),
-                GitRepository(movedCoreJava, mockRemote("core-java")))
+                GitRepository(movedCoreJava, mockRemote("core-java")),
+                Artifact(GroupId("io", "spine"), "spine-core"))
 
         val mostRecentVersion = Ordering(setOf(base, time, coreJava)).mostRecentVersion()
         assertThat(mostRecentVersion).isEqualTo(Version(1, 9, 9))
@@ -103,7 +108,8 @@ class OrderingTest {
     private fun mockLibrary(name: String, vararg dependencies: Library): Library {
         val path = Paths.get("") // A mock path doesn't matter as files aren't accessed.
         val deps: List<Library> = dependencies.toList()
-        return Library(name, deps, GitRepository(path, mockRemote(name)))
+        val artifact = Artifact(GroupId("io", "mock"), "library")
+        return Library(name, deps, GitRepository(path, mockRemote(name)), artifact)
     }
 
     private fun mockRemote(name: RepositoryName) = GitHubRepoUrl("test-org", name)

--- a/src/test/kotlin/io/spine/publishing/operation/UpdateVersionsTest.kt
+++ b/src/test/kotlin/io/spine/publishing/operation/UpdateVersionsTest.kt
@@ -24,6 +24,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import io.spine.publishing.Artifact
 import io.spine.publishing.GroupId
+import io.spine.publishing.LibrariesToPublish
 import io.spine.publishing.Library
 import io.spine.publishing.git.GitRepository
 import io.spine.publishing.given.PipelineTestEnv.sampleRemote
@@ -59,7 +60,7 @@ class UpdateVersionsTest {
                 GitRepository(movedCoreJava, sampleRemote),
                 Artifact(GroupId("io", "spine"), "spine-core"))
 
-        UpdateVersions().perform(setOf(base, time, coreJava))
+        UpdateVersions().perform(LibrariesToPublish.from(setOf(base, time, coreJava)))
 
         val expectedVersion = Version(1, 9, 9)
         assertThat(base.version()).isEqualTo(expectedVersion)
@@ -90,7 +91,7 @@ class UpdateVersionsTest {
                 GitRepository(libraryDir, sampleRemote),
                 Artifact(GroupId("level", "first"), "library"))
 
-        UpdateVersions().perform(setOf(library, subLibrary))
+        UpdateVersions().perform(LibrariesToPublish.from(setOf(library, subLibrary)))
 
         val versions = listOf(library.version(),
                 library.version(subLibrary.name),

--- a/src/test/kotlin/io/spine/publishing/operation/UpdateVersionsTest.kt
+++ b/src/test/kotlin/io/spine/publishing/operation/UpdateVersionsTest.kt
@@ -22,6 +22,8 @@ package io.spine.publishing.operation
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import io.spine.publishing.Artifact
+import io.spine.publishing.GroupId
 import io.spine.publishing.Library
 import io.spine.publishing.git.GitRepository
 import io.spine.publishing.given.PipelineTestEnv.sampleRemote
@@ -46,13 +48,16 @@ class UpdateVersionsTest {
 
         val base = Library("base",
                 listOf(),
-                GitRepository(movedBase, sampleRemote))
+                GitRepository(movedBase, sampleRemote),
+                Artifact(GroupId("io", "spine"), "spine-base"))
         val time = Library("time",
                 listOf(base),
-                GitRepository(movedTime, sampleRemote))
+                GitRepository(movedTime, sampleRemote),
+                Artifact(GroupId("io", "spine"), "spine-time"))
         val coreJava = Library("coreJava",
                 listOf(time, base),
-                GitRepository(movedCoreJava, sampleRemote))
+                GitRepository(movedCoreJava, sampleRemote),
+                Artifact(GroupId("io", "spine"), "spine-core"))
 
         UpdateVersions().perform(setOf(base, time, coreJava))
 
@@ -77,10 +82,13 @@ class UpdateVersionsTest {
 
         val subLibrary = Library("subLibrary",
                 listOf(),
-                GitRepository(subLibraryDir, sampleRemote))
+                GitRepository(subLibraryDir, sampleRemote),
+                Artifact(GroupId("rary", "lib"), "sub")
+        )
         val library = Library("library",
                 listOf(subLibrary),
-                GitRepository(libraryDir, sampleRemote))
+                GitRepository(libraryDir, sampleRemote),
+                Artifact(GroupId("level", "first"), "library"))
 
         UpdateVersions().perform(setOf(library, subLibrary))
 


### PR DESCRIPTION
This PR adds the check for the artifact presence before publishing the library.

Before, `io.spine.publishing.operation.Publish` used to publish the library without checking whether it's published first.

Now, it performs a query to `mycloudrepo` to check whether an artifact with such a version already exists. If it does, does not publish.

Also, this PR extracts the libraries that participate in the publishing pipeline into a separate class - `LibrariesToPublish`.

This class is aware of the library that had the highest version at the start of the pipeline. This library is called `updatedLibrary`. Pipeline operations now consume `LibrariesToPublish`, and thus, know the library that started with the highest version. As such, `EnsureBuilds` can now skip the version increment check for that library only.